### PR TITLE
Update Node in CI jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [24.x, 25.x, 26.x]
+        node-version: [24.x, 25.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [24.x, 25.x, 26.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Upgrading node versions since 18 and 20 are EOL and 22 will soon be EOL: https://nodejs.org/en/about/previous-releases