### PR TITLE
Set permissions for GH Actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -3,6 +3,9 @@
 
 name: Linting and Unit Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,6 +4,11 @@ on:
     branches: [ main, master ]
   pull_request:
     branches: [ main, master ]
+
+permissions:
+  contents: read
+
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
Addressing code scanning alerts that are flagging that both test jobs are too permissive